### PR TITLE
add support for SWC

### DIFF
--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"build": "rollup -c",
+		"build": "<%- variant==='typescript-swc' ? 'tsc --noEmit && ' : '' %>rollup -c",
 		"watch": "rollup -c -w --watch.onEnd=\"streamdeck restart <%- uuid %>\""
 	},
 	"type": "module",

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -8,12 +8,17 @@
 		"@elgato/cli": <%- JSON.stringify(npm.cli) %>,
 		"@rollup/plugin-commonjs": "^25.0.5",
 		"@rollup/plugin-node-resolve": "^15.2.2",
+		<%_ if (variant==='typescript' ) { _%>
 		"@rollup/plugin-terser": "^0.4.4",
 		"@rollup/plugin-typescript": "^11.1.5",
+		"tslib": "^2.6.2",
+		<%_ } else if (variant==='typescript-swc' ) { _%>
+		"@swc/core": "^1.3.95",
+		"rollup-plugin-swc3": "^0.10.3",
+		<%_ } _%>
 		"@tsconfig/node20": "^20.1.2",
 		"@types/node": "20.1.7",
 		"rollup": "^4.0.2",
-		"tslib": "^2.6.2",
 		"typescript": "^5.2.2"
 	},
 	"dependencies": {

--- a/template/rollup.config.mjs.ejs
+++ b/template/rollup.config.mjs.ejs
@@ -1,7 +1,11 @@
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
-import terser from "@rollup/plugin-terser";
+<% if (variant === 'typescript') { -%>
 import typescript from "@rollup/plugin-typescript";
+import terser from "@rollup/plugin-terser";
+<% } else if (variant==='typescript-swc' ) { -%>
+import { swc } from "rollup-plugin-swc3";
+<% } -%>
 import path from "node:path";
 import url from "node:url";
 
@@ -20,16 +24,30 @@ const config = {
 		}
 	},
 	plugins: [
+		<%_ if (variant === 'typescript') { _%>
 		typescript({
 			mapRoot: isWatching ? "./" : undefined
 		}),
+		<%_ } else if (variant==='typescript-swc' ) { _%>
+		swc({
+			minify: !isWatching,
+			sourceMaps: isWatching,
+			jsc: {
+				parser: {
+					decorators: true,
+				},
+			},
+		}),
+		<%_ } _%>
 		nodeResolve({
 			browser: false,
 			exportConditions: ["node"],
 			preferBuiltins: true
 		}),
 		commonjs(),
+		<%_ if (variant === 'typescript') { _%>
 		!isWatching && terser(),
+		<%_ } _%>
 		{
 			name: "emit-module-package-file",
 			generateBundle() {


### PR DESCRIPTION
Hello! I added  a new `create` option to allow the user to choose a Template (for rollup configuration).

```bash
? Author: author
? Plugin Name: plugin
? Plugin UUID: com.author.plugin
? Description: plugin
? Template:
❯ TypeScript
  TypeScript + SWC
```

I used some conditional rendering in `template/package.json.ejs` and `template/rollup.config.mjs`, do you prefer different files (one per variant) ?

---

Comparisons using the simple generated plugin (1 action only)
| **task** | **Typescript** | **Typescript + SWC** | **boost** |
|---------------|:--------------:|:--------------------:|:---------:|
| hot reload    |      389ms     |         149ms\*       |    2.6x   |
| build         |      1.3s      |         380ms\*        |   3.4x   |

\* without typechecking

---

LMKWYT