### PR TITLE
Fix path creation for Windows in getPluginsPath function

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -97,8 +97,12 @@ async function promptForPluginInfo(): Promise<PluginInfo> {
 					return "UUID can only contain lowercase alphanumeric characters (a-z, 0-9), hyphens (-), underscores (_), or periods (.).";
 				}
 
-				if (getPlugins().some((p) => p.uuid === uuid)) {
-					return "Another plugin with this UUID is already installed.";
+				try {
+					if (getPlugins().some((p) => p.uuid === uuid)) {
+						return "Another plugin with this UUID is already installed.";
+					}
+				} catch {
+					// Ignore.
 				}
 
 				return true;

--- a/src/stream-deck.ts
+++ b/src/stream-deck.ts
@@ -32,7 +32,7 @@ export function getPluginsPath(): string {
 	}
 
 	const appData = process.env.APPDATA ?? join(os.homedir(), "AppData/Roaming");
-	return join(appData, "Elgato/StreamDeck/Plugins");
+	return join(appData, "Elgato", "StreamDeck", "Plugins");
 }
 
 /**
@@ -151,7 +151,10 @@ class PluginInfo {
 	 * @param entry The directory entry of the plugin.
 	 * @param uuid Unique identifier of the plugin.
 	 */
-	constructor(private readonly entry: Dirent, public readonly uuid: string) {
+	constructor(
+		private readonly entry: Dirent,
+		public readonly uuid: string
+	) {
 		this.path = join(this.entry.path, this.entry.name);
 	}
 


### PR DESCRIPTION
### Summary of Changes

This PR corrects an issue in the `getPluginsPath` function where the path was incorrectly formatted on Windows systems. Previously, the path looked like `C:\Users\user\AppData\Roaming Elgato/StreamDeck/Plugins`, and this has been fixed to use the correct path separators.

Additionally, the changes include a try-catch block to handle potential errors when checking for existing plugins by UUID. This prevents the `TypeError [ERR_INVALID_ARG_TYPE]` from propagating if encountered.

### Before

Previously, the path on Windows looked like: `C:\Users\user\AppData\Roaming Elgato/StreamDeck/Plugins`

### After

Now, the corrected path is used: `C:\Users\user\AppData\Roaming\Elgato\StreamDeck\Plugins`

### Testing

- Tested on Windows to ensure the corrected path is generated successfully.
