### PR TITLE
deps: update @types/node to include "fetch" types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@types/ejs": "^3.1.3",
 				"@types/inquirer": "^9.0.3",
 				"@types/lodash": "^4.14.199",
-				"@types/node": "20.1.7",
+				"@types/node": "^20.8.10",
 				"@typescript-eslint/eslint-plugin": "^6.7.4",
 				"@typescript-eslint/parser": "^6.7.4",
 				"ajv": "^8.12.0",
@@ -1043,10 +1043,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.1.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.7.tgz",
-			"integrity": "sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg==",
-			"dev": true
+			"version": "20.8.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+			"integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
@@ -4114,6 +4117,12 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"node_modules/untildify": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"@types/ejs": "^3.1.3",
 		"@types/inquirer": "^9.0.3",
 		"@types/lodash": "^4.14.199",
-		"@types/node": "20.1.7",
+		"@types/node": "^20.8.10",
 		"@typescript-eslint/eslint-plugin": "^6.7.4",
 		"@typescript-eslint/parser": "^6.7.4",
 		"ajv": "^8.12.0",

--- a/src/common/stdout.ts
+++ b/src/common/stdout.ts
@@ -80,7 +80,7 @@ class ConsoleStdOut {
 	/**
 	 * Identifies the timer responsible for displaying the spinning symbol.
 	 */
-	private timerId?: NodeJS.Timer;
+	private timerId?: NodeJS.Timeout;
 
 	/**
 	 * Initializes a new instance of the {@link ConsoleStdOut} class.

--- a/template/com.elgato.template.sdPlugin/manifest.json.ejs
+++ b/template/com.elgato.template.sdPlugin/manifest.json.ejs
@@ -26,7 +26,7 @@
 	"Icon": "imgs/plugin/marketplace",
 	"SDKVersion": 2,
 	"Software": {
-		"MinimumVersion": "6.4"
+		"MinimumVersion": "6.5"
 	},
 	"OS": [
 		{

--- a/template/package.json.ejs
+++ b/template/package.json.ejs
@@ -11,7 +11,7 @@
 		"@rollup/plugin-terser": "^0.4.4",
 		"@rollup/plugin-typescript": "^11.1.5",
 		"@tsconfig/node20": "^20.1.2",
-		"@types/node": "20.1.7",
+		"@types/node": "20.8.10",
 		"rollup": "^4.0.2",
 		"tslib": "^2.6.2",
 		"typescript": "^5.2.2"


### PR DESCRIPTION
- Update `@types/node` to 20.8.10, in CLI and template, to gain types for `fetch`.
- Update template's `manifest.json` to target Stream Deck 6.5.