### PR TITLE
feat: add option to display cli version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,17 @@
 ### ♻️ Improvements
 
 - Add "Open in VSCode" prompt, as part of creation wizard, for macOS.
+- Add `-v, --version` option to display current version of CLI.
+
+### 🐞 Bug Fixes
+
+- Fix support for Visual Studio integrated output.
 
 ## 0.2.0
 
 ### ✨ New
 
--  Add [`packageManager`](README.md/#packagemanager) configuration option ([@fcannizzaro](https://github.com/fcannizzaro)).
+- Add [`packageManager`](README.md/#packagemanager) configuration option ([@fcannizzaro](https://github.com/fcannizzaro)).
 
 ### ♻️ Improvements
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,3 +5,4 @@ export { link } from "./link";
 export { restart } from "./restart";
 export { stop } from "./stop";
 export { validate } from "./validate";
+export { cliVersion } from "./version";

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+import { command } from "../common/command";
+import { relative } from "../common/path";
+
+/**
+ * Prints the current version of the CLI.
+ */
+export const cliVersion = command(async (options, stdout) => {
+	try {
+		const contents = readFileSync(relative("../package.json"), { encoding: "utf8" });
+		const version = `v${JSON.parse(contents).version}`;
+
+		if (existsSync(relative("../src"))) {
+			stdout.log(`${version} (dev)`);
+		} else {
+			stdout.log(version);
+		}
+	} catch (e) {
+		stdout.error(`Failed to read CLI version`).log(e).exit(1);
+	}
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 import { program } from "commander";
 
-import { config, create, link, restart, setDeveloperMode, stop, validate } from "./commands";
+import { cliVersion, config, create, link, restart, setDeveloperMode, stop, validate } from "./commands";
+
+program.option("-v, --version", "display CLI version").action((opts) => {
+	if (opts.version) {
+		cliVersion();
+	} else {
+		program.help();
+	}
+});
 
 program
 	.command("create")


### PR DESCRIPTION
- Adds support for `-v` | `--version` to display the current CLI version.
- Updates changelogs.