### PR TITLE
fix: revert version on --dry-run

### DIFF
--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -77,6 +77,7 @@ export const pack = command<PackOptions>(
 
 		if (options.dryRun) {
 			stdout.info("No package created, --dry-run flag is present").log().log(chalk.dim(outputPath));
+			versioner?.undo();
 		} else {
 			stdout.success("Successfully packaged plugin").log().log(outputPath);
 		}
@@ -177,7 +178,7 @@ async function version(path: string, version: string): Promise<VersionReverter> 
 		original = await readFile(manifestPath, { encoding: "utf-8" });
 
 		const manifest = JSON.parse(original);
-		manifest.Version = version;
+		manifest.Version = `${version}${".0".repeat(Math.max(0, 4 - version.split(".").length))}`;
 		write(JSON.stringify(manifest, undefined, "\t"));
 	}
 

--- a/template/com.elgato.template.sdPlugin/manifest.json.ejs
+++ b/template/com.elgato.template.sdPlugin/manifest.json.ejs
@@ -1,6 +1,6 @@
 {
 	"Name": <%- JSON.stringify(name) %>,
-	"Version": "0.1.0",
+	"Version": "0.1.0.0",
 	"Author": <%- JSON.stringify(author) %>,
 	"Actions": [
 		{


### PR DESCRIPTION
- Fix reverting of version number when `--version` specified with `--dry-run`.
- Update version to default to 4 segments to align with Marketplace.