### PR TITLE
build: drop support for cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,20 +6,14 @@
         "streamdeck": "bin/streamdeck.mjs",
         "sd": "bin/streamdeck.mjs"
     },
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        },
-        "./package.json": "./package.json"
-    },
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "files": [
         "./{bin,dist}/*.{js,cjs,mjs}",
         "./{bin,dist}/*.d.{cts,ts}",
         "./template"
     ],
-    "type": "module",
     "engines": {
         "node": "^20.1.0"
     },

--- a/src/json/schema.ts
+++ b/src/json/schema.ts
@@ -3,7 +3,7 @@ import { parse } from "@humanwhocodes/momoa";
 import Ajv, { type AnySchema, AnySchemaObject, type DefinedError, ErrorObject, KeywordDefinition } from "ajv";
 import { type AnyValidateFunction, DataValidationCxt } from "ajv/dist/types";
 import { type LimitNumberError } from "ajv/dist/vocabularies/validation/limitNumber";
-import { isEqual, uniqWith } from "lodash";
+import _ from "lodash";
 
 import { type JsonLocation, type LocationRef } from "../common/location";
 import { colorize } from "../common/stdout";
@@ -129,9 +129,9 @@ export class JsonSchema<T extends object> {
 		const ignoredKeywords = ["allOf", "anyOf", "if"];
 
 		// Remove ignored keywords, and remove duplicate errors.
-		return uniqWith(
+		return _.uniqWith(
 			errors.filter(({ keyword }) => !ignoredKeywords.includes(keyword)),
-			(a, b) => a.instancePath === b.instancePath && a.keyword === b.keyword && isEqual(a.params, b.params),
+			(a, b) => a.instancePath === b.instancePath && a.keyword === b.keyword && _.isEqual(a.params, b.params),
 		);
 	}
 

--- a/src/validation/file-result.ts
+++ b/src/validation/file-result.ts
@@ -11,7 +11,7 @@ export class FileValidationResult extends OrderedArray<ValidationEntry> {
 	/**
 	 * Tracks the padding required for the location of a validation entry, i.e. the text before the entry level.
 	 */
-	private padding = 0;
+	#padding = 0;
 
 	/**
 	 * Initializes a new instance of the {@link FileValidationResult} class.
@@ -32,7 +32,7 @@ export class FileValidationResult extends OrderedArray<ValidationEntry> {
 	 * @returns New length of the validation results.
 	 */
 	public push(entry: ValidationEntry): number {
-		this.padding = Math.max(this.padding, entry.location.length);
+		this.#padding = Math.max(this.#padding, entry.location.length);
 		return super.push(entry);
 	}
 
@@ -52,7 +52,7 @@ export class FileValidationResult extends OrderedArray<ValidationEntry> {
 			output.log();
 		}
 
-		this.forEach((entry) => output.log(entry.toSummary(this.padding)));
+		this.forEach((entry) => output.log(entry.toSummary(this.#padding)));
 		output.log();
 	}
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig([
 			index: "src/index.ts",
 		},
 		outDir: "dist",
-		format: ["cjs", "esm"],
+		format: ["esm"],
 		banner,
 		clean: true,
 		dts: true,


### PR DESCRIPTION
It transpires that `Chalk` and `lodash` are a troublesome pair for CommonJS _and_ ESM. With ESM being the preferred choice, this PR removes support for CJS before becoming public.