### PR TITLE
refactor: default to noImplicitOverride

### DIFF
--- a/template/src/actions/increment-counter.ts.ejs
+++ b/template/src/actions/increment-counter.ts.ejs
@@ -10,7 +10,7 @@ export class IncrementCounter extends SingletonAction<CounterSettings> {
 	 * starting up, or the user navigating between pages / folders etc.. There is also an inverse of this event in the form of {@link streamDeck.client.onWillDisappear}. In this example,
 	 * we're setting the title to the "count" that is incremented in {@link IncrementCounter.onKeyDown}.
 	 */
-	onWillAppear(ev: WillAppearEvent<CounterSettings>): void | Promise<void> {
+	override onWillAppear(ev: WillAppearEvent<CounterSettings>): void | Promise<void> {
 		return ev.action.setTitle(`${ev.payload.settings.count ?? 0}`);
 	}
 
@@ -20,7 +20,7 @@ export class IncrementCounter extends SingletonAction<CounterSettings> {
 	 * and action information where applicable. In this example, our action will display a counter that increments by one each press. We track the current count on the action's persisted
 	 * settings using `setSettings` and `getSettings`.
 	 */
-	async onKeyDown(ev: KeyDownEvent<CounterSettings>): Promise<void> {
+	override async onKeyDown(ev: KeyDownEvent<CounterSettings>): Promise<void> {
 		// Update the count from the settings.
 		const { settings } = ev.payload;
 		settings.incrementBy ??= 1;

--- a/template/tsconfig.json.ejs
+++ b/template/tsconfig.json.ejs
@@ -5,7 +5,8 @@
 			"node"
 		],
 		"module": "ES2022",
-		"moduleResolution": "Bundler"
+		"moduleResolution": "Bundler",
+		"noImplicitOverride": true
 	},
 	"include": [
 		"src/**/*.ts"


### PR DESCRIPTION
Overriding methods in TypeScript is easy... _too_ easy. This pull request adds the `override` keyword, and defaults to `noImplicitOverride`. This protects us from future changes that might go unnoticed, for example:

Before - no `override` keyword, and `noImplicitOverride` set to `false`.

1. A future change in `@elgato/streamdeck` renames `onWillDisappear` to `onDisappear`.
2. The plugin builds.
3. The plugin doesn't receive the `onDisappear` event as the method is overriding `onWillDisappear`.
4. The plugin breaks quietly.

After - `override` keyword and `noImplicitOverride` set to `true`.

1. A future change in `@elgato/streamdeck` renames `onWillDisappear` to `onDisappear`.
2. The plugin build fails.
3. The Maker updates `onWillDisappear` to be `onDisappear` as part of the upgrade, and everything works.