### PR TITLE
feat: add list and unlink commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 
 # Change Log
 
+## vNext
+
+### ✨ New
+
+-   Add `list` command to display list of installed plugins.
+-   Add `unlink` command to unlink installed plugins.
+
 ## 1.4.0
 
 ### ♻️ Update

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Stream Deck CLI
 
 [![SDK documentation](https://img.shields.io/badge/Documentation-2ea043?labelColor=grey&logo=gitbook&logoColor=white)](https://docs.elgato.com/streamdeck/cli)
-[![Elgato homepage](https://img.shields.io/badge/Elgato-3431cf?labelColor=grey&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+RWxnYXRvPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJtMTMuODgxOCA4LjM5NjQuMDI2MS4wMTk2IDkuOTQ5NCA1LjcxNzJjLS40ODg0IDIuNzI5LTEuOTE5NiA1LjIyMjMtNC4wMzg0IDcuMDI1M0ExMS45MjYyIDExLjkyNjIgMCAwIDEgMTIuMDk3IDI0Yy0zLjE5MjUgMC02LjE5MzktMS4yNDc3LTguNDUyNy0zLjUxNDRDMS4zODY4IDE4LjIxODguMTQyNyAxNS4yMDQ0LjE0MjcgMTJjMC0zLjIwNDIgMS4yNDQtNi4yMTg3IDMuNTAxNS04LjQ4NTRDNS45MDE5IDEuMjQ4IDguOTAzMiAwIDEyLjA5NyAwYzIuNDM5NCAwIDQuNzg0Ny43MzMzIDYuNzgzIDIuMTE4NyAxLjk1MjYgMS4zNTQgMy40NDY2IDMuMjM1NyA0LjMyMjcgNS40NDIyLjExMTIuMjgyOS4yMTQ5LjU3MzYuMzA1MS44NjU3bC0yLjEyNTUgMS4yMzU5YTkuNDkyNCA5LjQ5MjQgMCAwIDAtLjI2MTktLjg2OTRjLTEuMzU0LTMuODMwMy00Ljk4MTMtNi40MDQ4LTkuMDIzNy02LjQwNDhDNi44MTcxIDIuMzg4MyAyLjUyMiA2LjcwMDUgMi41MjIgMTJjMCA1LjI5OTUgNC4yOTUgOS42MTE1IDkuNTc0OCA5LjYxMTUgMi4wNTIgMCA0LjAwODQtLjY0NDIgNS42NTk2LTEuODY0NyAxLjYxNzItMS4xOTU1IDIuODAzNi0yLjgzMzcgMy40MzA5LTQuNzM2NGwuMDA2NS0uMDQxOUw5LjU5MDYgOC4zMDQ4djcuMjI1Nmw0LjAwMDQtMi4zMTM4IDIuMDYgMS4xODExLTUuOTk2MiAzLjQ2ODgtMi4xMi0xLjIxMjZWNy4xOTQzbDIuMTE3NC0xLjIyNDUgNC4yMzA5IDIuNDI3OS0uMDAxMy0uMDAxMyIvPjwvc3ZnPg==)](https://elgato.com)
+[![Elgato homepage](https://img.shields.io/badge/Elgato-3431cf?labelColor=grey&logo=elgato)](https://elgato.com)
 [![Join the Marketplace Makers Discord](https://img.shields.io/badge/Marketplace%20Makers-5662f6?labelColor=grey&logo=discord&logoColor=white)](https://discord.gg/GehBUcu627)
 [![Stream Deck CLI npm package](https://img.shields.io/npm/v/%40elgato/cli?logo=npm&logoColor=white)](https://www.npmjs.com/package/@elgato/cli)
 [![Build status](https://img.shields.io/github/actions/workflow/status/elgatosf/cli/build.yml?branch=main&label=Build&logo=GitHub)](https://github.com/elgatosf/cli/actions)
@@ -25,18 +25,20 @@ Usage: streamdeck [options] [command]
 
 Options:
   -v                            display CLI version
+  -l, --list                    display list of installed plugins
   -h, --help                    display help for command
 
 Commands:
   create                        Stream Deck plugin creation wizard.
   link [path]                   Links the plugin to Stream Deck.
+  unlink [options] <uuid>       Unlinks the plugin from Stream Deck.
+  list [options]                Display list of installed plugins.
   restart|r <uuid>              Starts the plugin in Stream Deck; if the plugin is already running, it is stopped first.
   stop|s <uuid>                 Stops the plugin in Stream Deck.
   dev [options]                 Enables developer mode.
   validate [options] [path]     Validates the Stream Deck plugin.
   pack|bundle [options] [path]  Creates a .streamDeckPlugin file from the plugin.
   config                        Manage the local configuration.
-  help [command]                display help for command
 
 Alias:
   streamdeck

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,6 @@ import { program } from "commander";
 import { config, create, link, list, pack, restart, setDeveloperMode, stop, unlink, validate } from "./commands";
 import { packageManager } from "./package-manager";
 
-program.version(packageManager.getVersion({ checkEnvironment: true }), "-v", "display CLI version");
-
 program
 	.command("create")
 	.description("Stream Deck plugin creation wizard.")
@@ -96,4 +94,14 @@ configCommand
 	.description("Resets all configuration.")
 	.action(() => config.reset());
 
-program.parse();
+program
+	.version(packageManager.getVersion({ checkEnvironment: true }), "-v", "display CLI version")
+	.option("-l, --list", "display list of installed plugins")
+	.action((opts) => {
+		if (opts.list) {
+			list();
+		} else {
+			program.help();
+		}
+	})
+	.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,8 +22,12 @@ program
 	.option("-d|--delete", "Enable deletion of non-linked plugins.")
 	.action((uuid, opts) => unlink({ uuid, ...opts }));
 
-program.option("-l,--list").description("Prints a list of installed plugins").action(list);
-program.command("list").description("Prints a list of installed plugins").action(list);
+program.option("-l|--list").description("Prints a list of installed plugins").action(list);
+program
+	.command("list")
+	.option("-a|--all", "Show all plugins", false)
+	.description("Prints a list of installed plugins")
+	.action((opts) => list(opts));
 
 program
 	.command("restart")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import { program } from "commander";
 
-import { config, create, link, pack, restart, setDeveloperMode, stop, validate } from "./commands";
+import { config, create, link, list, pack, restart, setDeveloperMode, stop, validate } from "./commands";
 import { packageManager } from "./package-manager";
 
 program.version(packageManager.getVersion({ checkEnvironment: true }), "-v", "display CLI version");
@@ -15,6 +15,9 @@ program
 	.argument("[path]", "Path of the plugin to link.")
 	.description("Links the plugin to Stream Deck.")
 	.action((path) => link({ path }));
+
+program.option("-l,--list").description("Prints a list of installed plugins").action(list);
+program.command("list").description("Prints a list of installed plugins").action(list);
 
 program
 	.command("restart")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import { program } from "commander";
 
-import { config, create, link, list, pack, restart, setDeveloperMode, stop, validate } from "./commands";
+import { config, create, link, list, pack, restart, setDeveloperMode, stop, unlink, validate } from "./commands";
 import { packageManager } from "./package-manager";
 
 program.version(packageManager.getVersion({ checkEnvironment: true }), "-v", "display CLI version");
@@ -15,6 +15,12 @@ program
 	.argument("[path]", "Path of the plugin to link.")
 	.description("Links the plugin to Stream Deck.")
 	.action((path) => link({ path }));
+
+program
+	.command("unlink")
+	.argument("<uuid>")
+	.option("-d|--delete", "Enable deletion of non-linked plugins.")
+	.action((uuid, opts) => unlink({ uuid, ...opts }));
 
 program.option("-l,--list").description("Prints a list of installed plugins").action(list);
 program.command("list").description("Prints a list of installed plugins").action(list);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,13 +20,13 @@ program
 	.command("unlink")
 	.argument("<uuid>")
 	.option("-d|--delete", "Enable deletion of non-linked plugins.")
+	.description("Unlinks the plugin from Stream Deck.")
 	.action((uuid, opts) => unlink({ uuid, ...opts }));
 
-program.option("-l|--list").description("Prints a list of installed plugins").action(list);
 program
 	.command("list")
 	.option("-a|--all", "Show all plugins", false)
-	.description("Prints a list of installed plugins")
+	.description("Display list of installed plugins.")
 	.action((opts) => list(opts));
 
 program

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,4 +6,5 @@ export { list } from "./list";
 export { pack } from "./pack";
 export { restart } from "./restart";
 export { stop } from "./stop";
+export { unlink } from "./unlink";
 export { validate } from "./validate";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,6 +2,7 @@ export * as config from "./config";
 export { create } from "./create";
 export { setDeveloperMode } from "./dev";
 export { link } from "./link";
+export { list } from "./list";
 export { pack } from "./pack";
 export { restart } from "./restart";
 export { stop } from "./stop";

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -37,7 +37,7 @@ export const link = command<LinkOptions>(
 		// Check if there is a conflict with an already installed plugin.
 		const existing = getPlugins().find((p) => p.uuid === uuid);
 		if (existing) {
-			if (existing.sourcePath !== null && resolve(existing.sourcePath) === resolve(options.path)) {
+			if (existing.targetPath !== null && resolve(existing.targetPath) === resolve(options.path)) {
 				feedback.success("Linked successfully");
 				return;
 			} else {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,16 +7,38 @@ import { getPlugins } from "../stream-deck";
 /**
  * Prints a list of installed plugins
  */
-export const list = command(async (options, output) => {
-	const plugins = getPlugins();
-	for (const { targetPath, uuid } of plugins) {
-		output.log(uuid);
-		if (targetPath) {
-			if (existsSync(targetPath)) {
-				console.log(chalk.dim("  └"), chalk.green(targetPath));
+export const list = command<Options>(
+	async (options, output) => {
+		const plugins = getPlugins();
+		for (const plugin of plugins) {
+			if (!plugin.isLink && !options.all) {
+				continue;
+			}
+
+			const { uuid, targetPath } = plugin;
+
+			if (targetPath) {
+				if (existsSync(targetPath)) {
+					output.log(`${uuid} ${chalk.dim("→")} ${chalk.green(targetPath)}`);
+				} else {
+					output.log(`${uuid} ${chalk.dim("→")} ${chalk.red(targetPath)} ${chalk.dim("(not found)")}`);
+				}
 			} else {
-				console.log(chalk.dim("  └ Not Found:"), chalk.red(targetPath));
+				output.log(uuid);
 			}
 		}
-	}
-});
+	},
+	{
+		all: false,
+	},
+);
+
+/**
+ * Options for the {@link list} command.
+ */
+type Options = {
+	/**
+	 * Determines whether to show all plugins; when `false` only linked plugins are shown. Default is `false`.
+	 */
+	all?: boolean;
+};

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -9,13 +9,13 @@ import { getPlugins } from "../stream-deck";
  */
 export const list = command(async (options, output) => {
 	const plugins = getPlugins();
-	for (const { targetPath: sourcePath, uuid } of plugins) {
+	for (const { targetPath, uuid } of plugins) {
 		output.log(uuid);
-		if (sourcePath) {
-			if (existsSync(sourcePath)) {
-				console.log(chalk.dim("  └"), chalk.green(sourcePath));
+		if (targetPath) {
+			if (existsSync(targetPath)) {
+				console.log(chalk.dim("  └"), chalk.green(targetPath));
 			} else {
-				console.log(chalk.dim("  └ Not Found:"), chalk.red(sourcePath));
+				console.log(chalk.dim("  └ Not Found:"), chalk.red(targetPath));
 			}
 		}
 	}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -9,7 +9,7 @@ import { getPlugins } from "../stream-deck";
  */
 export const list = command(async (options, output) => {
 	const plugins = getPlugins();
-	for (const { sourcePath, uuid } of plugins) {
+	for (const { targetPath: sourcePath, uuid } of plugins) {
 		output.log(uuid);
 		if (sourcePath) {
 			if (existsSync(sourcePath)) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,0 +1,22 @@
+import chalk from "chalk";
+import { existsSync } from "node:fs";
+
+import { command } from "../common/command";
+import { getPlugins } from "../stream-deck";
+
+/**
+ * Prints a list of installed plugins
+ */
+export const list = command(async (options, output) => {
+	const plugins = getPlugins();
+	for (const { sourcePath, uuid } of plugins) {
+		output.log(uuid);
+		if (sourcePath) {
+			if (existsSync(sourcePath)) {
+				console.log(chalk.dim("  └"), chalk.green(sourcePath));
+			} else {
+				console.log(chalk.dim("  └ Not Found:"), chalk.red(sourcePath));
+			}
+		}
+	}
+});

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -17,7 +17,8 @@ export const stop = command<StopOptions>(async ({ uuid }, output) => {
 
 	// When Stream Deck isn't running, warn the user.
 	if (!(await isStreamDeckRunning())) {
-		return output.info("Stream Deck is not running.").exit();
+		output.info("Stream Deck is not running.");
+		return;
 	}
 
 	// Stop the plugin.

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -1,0 +1,55 @@
+import { unlinkSync } from "node:fs";
+
+import { command } from "../common/command";
+import { getPlugins } from "../stream-deck";
+import { stop } from "./stop";
+
+/**
+ * Unlinks / uninstalls a plugin from Stream Deck's plugin directory.
+ */
+export const unlink = command<Options>(
+	async (options, output) => {
+		const plugin = getPlugins().find(({ uuid }) => uuid === options.uuid);
+		if (!plugin) {
+			return output.error("Plugin not found").log(`No plugin found with UUID: ${options.uuid}`).exit(1);
+		}
+
+		if (!plugin.targetPath) {
+			if (!options.delete) {
+				return output
+					.error("Plugin cannot be unlinked")
+					.log(`${options.uuid} is not a linked plugin`)
+					.log(`To uninstall and delete the plugin, re-run with the delete flag (-d|--delete)`)
+					.exit(1);
+			}
+
+			// TODO: Stop the plugin and remove it.
+			console.log("TODO: Stop the plugin and remove it.");
+			return;
+		} else {
+			// Stop the plugin and remove the link.
+			await stop({ quiet: true, uuid: options.uuid });
+			unlinkSync(plugin.path);
+		}
+
+		output.success("Unlinked successfully");
+	},
+	{
+		delete: false,
+	},
+);
+
+/**
+ * Options for {@link unlink}.
+ */
+type Options = {
+	/**
+	 * Enables deleting plugins that are not symbolic-links; default `false`.
+	 */
+	delete?: boolean;
+
+	/**
+	 * Unique-identifier of the plugin to unlink, for example `com.elgato.wave-link`.
+	 */
+	uuid: string;
+};

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -14,7 +14,7 @@ export const unlink = command<Options>(
 			return output.error("Plugin not found").log(`No plugin found with UUID: ${options.uuid}`).exit(1);
 		}
 
-		if (!plugin.targetPath) {
+		if (!plugin.isLink) {
 			if (!options.delete) {
 				return output
 					.error("Plugin cannot be unlinked")

--- a/src/common/stdout.ts
+++ b/src/common/stdout.ts
@@ -185,7 +185,10 @@ class ConsoleStdOut {
 	 * @param task Task that the spinner represents.
 	 * @returns A promise fulfilled when the {@link task} completes.
 	 */
-	public async spin(message: string, task?: (writer: ConsoleStdOut) => Promise<number | void> | void): Promise<void> {
+	public async spin(
+		message: string,
+		task?: (writer: ConsoleStdOut, spin: Spinner) => Promise<number | void> | void,
+	): Promise<void> {
 		// Confirm we can spin.
 		if (this.options.level < MessageLevel.LOG) {
 			return;
@@ -203,7 +206,9 @@ class ConsoleStdOut {
 		} else {
 			try {
 				this.startSpinner();
-				await task(this);
+				await task(this, {
+					setText: (message: string) => (this.message = message),
+				});
 
 				if (this.isLoading) {
 					this.success();
@@ -309,6 +314,13 @@ class ConsoleStdOut {
 		return this;
 	}
 }
+
+/**
+ * Spinner that indicates a busy status.
+ */
+type Spinner = {
+	setText(message: string): void;
+};
 
 /**
  * Provides logging and exiting facilities as part of reporting an error.

--- a/src/stream-deck.ts
+++ b/src/stream-deck.ts
@@ -190,9 +190,9 @@ export class PathError extends Error {
  */
 class PluginInfo {
 	/**
-	 * Private backing field for {@link PluginInfo.sourcePath}.
+	 * Private backing field for {@link PluginInfo.targetPath}.
 	 */
-	private _sourcePath: string | null | undefined = undefined;
+	private _targetPath: string | null | undefined = undefined;
 
 	/**
 	 * Initializes a new instance of the {@link PluginInfo} class.
@@ -201,20 +201,20 @@ class PluginInfo {
 	 * @param uuid Unique identifier of the plugin.
 	 */
 	constructor(
-		private readonly path: string,
+		public readonly path: string,
 		private readonly entry: Dirent,
 		public readonly uuid: string,
 	) {}
 
 	/**
-	 * Gets the source path of the plugin, when the installation path is a symbolic link; otherwise `null`.
-	 * @returns The source path; otherwise `null`.
+	 * When the installed plugin is a symbolic link, the target path is the location of the file on disk.
+	 * @returns The target path; otherwise `null`.
 	 */
-	public get sourcePath(): string | null {
-		if (this._sourcePath === undefined) {
-			this._sourcePath = this.entry.isSymbolicLink() ? readlinkSync(this.path) : null;
+	public get targetPath(): string | null {
+		if (this._targetPath === undefined) {
+			this._targetPath = this.entry.isSymbolicLink() ? readlinkSync(this.path) : null;
 		}
 
-		return this._sourcePath;
+		return this._targetPath;
 	}
 }

--- a/src/stream-deck.ts
+++ b/src/stream-deck.ts
@@ -207,6 +207,14 @@ class PluginInfo {
 	) {}
 
 	/**
+	 * Gets a value indicating whether the plugin is a linked (dev) plugin.
+	 * @returns `true` when the plugin is linked; otherwise `false`.
+	 */
+	public get isLink(): boolean {
+		return this.targetPath !== null;
+	}
+
+	/**
 	 * When the installed plugin is a symbolic link, the target path is the location of the file on disk.
 	 * @returns The target path; otherwise `null`.
 	 */


### PR DESCRIPTION
- Adds `list [-a, --all]` command.
  - Displays list of installed (linked) plugins.
  - When optional `-a, --all` flag is true, all plugins will be displayed.
- Adds `-l` top-level option to display linked plugins.
- Adds `unlink <uuid> [-d, --delete]` command.
  - Unlinks a linked plugin.
  - When `-d, --delete` is true, allows for removing installed plugins that aren't linked.
