### PR TITLE
feat: skip file list output after packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### ✨ New
 
-- Add `--skip-file-list` flag to omit outputting the list of files after packaging.
+- Add `--no-file-list` flag to omit outputting the list of files after packaging.
 
 ## 1.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### ✨ New
 
-- Add `--no-file-list` flag to omit outputting the list of files after packaging.
+- Add `--no-file-list` to disable showing the list of files after packaging.
 
 ## 1.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,161 +11,167 @@
 
 # Change Log
 
+## 1.8.0
+
+### ✨ New
+
+- Add `--skip-file-list` flag to omit outputting the list of files after packaging.
+
 ## 1.7.4
 
 ### ♻️ Update
 
--   Update template to default to Stream Deck 7.1 and Node.js 24.
+- Update template to default to Stream Deck 7.1 and Node.js 24.
 
 ## 1.7.3
 
 ### ♻️ Update
 
--   Migrate to `rolldown` for improved CLI build times.
--   Update `@elgato/schemas` dependency.
+- Migrate to `rolldown` for improved CLI build times.
+- Update `@elgato/schemas` dependency.
 
 ## 1.7.1
 
 ### ♻️ Update
 
--   Add support for validating JSON files in UTF-8 with BOM.
+- Add support for validating JSON files in UTF-8 with BOM.
 
 ## 1.7.0
 
 ### ✨ New
 
--   Add smart-formatting of the manifest.json to retain preferred indentation and new-lines.
+- Add smart-formatting of the manifest.json to retain preferred indentation and new-lines.
 
 ### ♻️ Update
 
--   Update `tar` and `tsup` dependencies.
+- Update `tar` and `tsup` dependencies.
 
 ## 1.6.0
 
 ### ♻️ Update
 
--   Updated template to use `@elgato/streamdeck` version 2.
+- Updated template to use `@elgato/streamdeck` version 2.
 
 ## 1.5.1
 
 ### ♻️ Update
 
--   Reduce strictness of Stream Deck app location checking.
+- Reduce strictness of Stream Deck app location checking.
 
 ## 1.5.0
 
 ### ✨ New
 
--   Add `list` command to display list of installed plugins.
--   Add `unlink` command to unlink installed plugins.
+- Add `list` command to display list of installed plugins.
+- Add `unlink` command to unlink installed plugins.
 
 ### 🐞 Fix
 
--   Resolve DEP0190 warning when using Node.js 24 or higher.
+- Resolve DEP0190 warning when using Node.js 24 or higher.
 
 ## 1.4.0
 
 ### ♻️ Update
 
--   Update `create` command to show newly created plugins within Stream Deck.
+- Update `create` command to show newly created plugins within Stream Deck.
 
 ## 1.3.0
 
 ### ♻️ Update
 
--   Update default minimum version of Stream Deck to 6.5.
--   Update sdpi-components to version 4.
+- Update default minimum version of Stream Deck to 6.5.
+- Update sdpi-components to version 4.
 
 ## 1.2.0
 
 ### ♻️ Update
 
--   Update `restart` & `stop` commands utilize deep links.
+- Update `restart` & `stop` commands utilize deep links.
 
 ## 1.1.1
 
--   Update default macOS minimum version to 12.
--   Update dependencies.
+- Update default macOS minimum version to 12.
+- Update dependencies.
 
 ## 1.1.0
 
 ### ✨ New
 
--   Add support for non-standard installation paths on Windows.
+- Add support for non-standard installation paths on Windows.
 
 ## 1.0.1
 
 ### ♻️ Update
 
--   Update `@elgato/schemas` dependency.
+- Update `@elgato/schemas` dependency.
 
 ### 🐞 Fix
 
--   Fix Node.js engine requirements.
+- Fix Node.js engine requirements.
 
 ## 1.0.0
 
 ### ♻️ Update
 
--   Update new plugins to use `@elgato/streamdeck` version 1.
--   Update CDN of property inspectors.
--   Bump dependencies of Stream Deck CLI.
--   Bump dependencies of plugins scaffolded with `streamdeck create`.
+- Update new plugins to use `@elgato/streamdeck` version 1.
+- Update CDN of property inspectors.
+- Bump dependencies of Stream Deck CLI.
+- Bump dependencies of plugins scaffolded with `streamdeck create`.
 
 ## 0.3.2
 
 ### ♻️ Update
 
--   Update template to include a property inspector.
--   Update template to auto-resolve JSON schemas for the manifest and layouts.
--   Remove subjective VS Code settings.
+- Update template to include a property inspector.
+- Update template to auto-resolve JSON schemas for the manifest and layouts.
+- Remove subjective VS Code settings.
 
 ## 0.3.1
 
 ### ✨ New
 
--   Enable validation of Stream Deck plugins programmatically.
+- Enable validation of Stream Deck plugins programmatically.
 
 ## 0.3.0
 
 ### ✨ New
 
--   Add `streamdeck validate` command for validating Stream Deck plugins.
--   Add `streamdeck pack` command for creating `.streamDeckPlugin` files.
--   Add `-v` option to display current version of CLI.
--   Add "Open in VSCode" prompt, as part of creation wizard, for macOS.
+- Add `streamdeck validate` command for validating Stream Deck plugins.
+- Add `streamdeck pack` command for creating `.streamDeckPlugin` files.
+- Add `-v` option to display current version of CLI.
+- Add "Open in VSCode" prompt, as part of creation wizard, for macOS.
 
 ### ♻️ Update
 
--   Update template to `{major}.{minor}.{patch}.{build}` version format.
--   Update `streamdeck pack` to automatically adjust version format.
+- Update template to `{major}.{minor}.{patch}.{build}` version format.
+- Update `streamdeck pack` to automatically adjust version format.
 
 ### 🐞 Bug Fixes
 
--   Fix support for Visual Studio integrated terminal.
+- Fix support for Visual Studio integrated terminal.
 
 ## 0.2.0
 
 ### ✨ New
 
--   Add [`packageManager`](README.md/#packagemanager) configuration option ([@fcannizzaro](https://github.com/fcannizzaro)).
+- Add [`packageManager`](README.md/#packagemanager) configuration option ([@fcannizzaro](https://github.com/fcannizzaro)).
 
 ### ♻️ Improvements
 
--   Manifest changes now automatically reload the plugin whilst being watched.
--   Updated template dependency `@types/node` to add support for `fetch` types.
+- Manifest changes now automatically reload the plugin whilst being watched.
+- Updated template dependency `@types/node` to add support for `fetch` types.
 
 ### 🐞 Bug Fixes
 
--   Fix support for Node v18.
+- Fix support for Node v18.
 
 ## 0.1.0
 
 ### ✨ New
 
--   Add `create` wizard for quickly scaffolding Stream Deck plugins.
--   Add `link` command for linking plugins in-development to Stream Deck.
--   Add `restart` plugin; unloads the plugins and re-starts the plugin within Stream Deck.
--   Add `stop` plugin; unloads the plugin from Stream Deck.
--   Add `dev` mode toggle for managing developer mode.
--   Add `config` for managing local configuration.
+- Add `create` wizard for quickly scaffolding Stream Deck plugins.
+- Add `link` command for linking plugins in-development to Stream Deck.
+- Add `restart` plugin; unloads the plugins and re-starts the plugin within Stream Deck.
+- Add `stop` plugin; unloads the plugin from Stream Deck.
+- Add `dev` mode toggle for managing developer mode.
+- Add `config` for managing local configuration.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,8 +66,8 @@ program
 	.option("--version <version>", "Plugin version; value will be written to the manifest")
 	.option("--force-update-check", "Forces an update check", false)
 	.option("--no-update-check", "Disables updating schemas", true)
+	.option("--no-file-list", "Disables showing the list of files after packaging", false)
 	.option("--ignore-validation", "Bypass validation errors (not recommended)", false)
-	.option("--skip-file-list", "Omits listing the packaged files after packaging", false)
 	.action((path, opts) => pack({ ...opts, path }));
 
 const configCommand = program.command("config").description("Manage the local configuration.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,7 @@ program
 	.option("--force-update-check", "Forces an update check", false)
 	.option("--no-update-check", "Disables updating schemas", true)
 	.option("--ignore-validation", "Bypass validation errors (not recommended)", false)
+	.option("--skip-file-list", "Omits listing the packaged files after packaging", false)
 	.action((path, opts) => pack({ ...opts, path }));
 
 const configCommand = program.command("config").description("Manage the local configuration.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ program
 	.option("--version <version>", "Plugin version; value will be written to the manifest")
 	.option("--force-update-check", "Forces an update check", false)
 	.option("--no-update-check", "Disables updating schemas", true)
-	.option("--no-file-list", "Disables showing the list of files after packaging", false)
+	.option("--no-file-list", "Disables showing the list of files after packaging")
 	.option("--ignore-validation", "Bypass validation errors (not recommended)", false)
 	.action((path, opts) => pack({ ...opts, path }));
 

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -62,16 +62,20 @@ export const pack = command<PackOptions>(
 		const contents = await getPackageContents(sourcePath, pkgBuilder.add);
 		pkgBuilder.close();
 
-		// Print a summary of the contents.
+		// Print the summary.
 		stdout.log(`📦 ${contents.manifest.Name} (v${contents.manifest.Version})`);
-		stdout.log();
-		stdout.log(chalk.cyan("Plugin Contents"));
 
-		contents.files.forEach((file, i) => {
-			stdout.log(
-				`${chalk.dim(i === contents.files.length - 1 ? "└─" : "├─")}  ${file.size.text.padEnd(contents.sizePad)}  ${file.path.relative}`,
-			);
-		});
+		// Print the contents.
+		if (!options.skipFileList) {
+			stdout.log();
+			stdout.log(chalk.cyan("Plugin Contents"));
+
+			contents.files.forEach((file, i) => {
+				stdout.log(
+					`${chalk.dim(i === contents.files.length - 1 ? "└─" : "├─")}  ${file.size.text.padEnd(contents.sizePad)}  ${file.path.relative}`,
+				);
+			});
+		}
 
 		// Print the package details.
 		stdout
@@ -99,6 +103,7 @@ export const pack = command<PackOptions>(
 		output: process.cwd(),
 		version: null,
 		ignoreValidation: false,
+		skipFileList: false,
 	},
 );
 
@@ -232,6 +237,11 @@ type PackOptions = ValidateOptions & {
 	 * Output directory where the plugin package will be written too; defaults to cwd.
 	 */
 	output?: string;
+
+	/**
+	 * When `true`, the list of packaged files will not be output to the console.
+	 */
+	skipFileList?: boolean;
 
 	/**
 	 * Optional version of the plugin; this will be set in the manifest before bundling.

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -66,7 +66,7 @@ export const pack = command<PackOptions>(
 		stdout.log(`📦 ${contents.manifest.Name} (v${contents.manifest.Version})`);
 
 		// Print the contents.
-		if (!options.skipFileList) {
+		if (!options.noFileList) {
 			stdout.log();
 			stdout.log(chalk.cyan("Plugin Contents"));
 
@@ -103,7 +103,7 @@ export const pack = command<PackOptions>(
 		output: process.cwd(),
 		version: null,
 		ignoreValidation: false,
-		skipFileList: false,
+		noFileList: false,
 	},
 );
 
@@ -241,7 +241,7 @@ type PackOptions = ValidateOptions & {
 	/**
 	 * When `true`, the list of packaged files will not be output to the console.
 	 */
-	skipFileList?: boolean;
+	noFileList?: boolean;
 
 	/**
 	 * Optional version of the plugin; this will be set in the manifest before bundling.

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -66,7 +66,7 @@ export const pack = command<PackOptions>(
 		stdout.log(`📦 ${contents.manifest.Name} (v${contents.manifest.Version})`);
 
 		// Print the contents.
-		if (!options.noFileList) {
+		if (options.fileList) {
 			stdout.log();
 			stdout.log(chalk.cyan("Plugin Contents"));
 
@@ -103,7 +103,7 @@ export const pack = command<PackOptions>(
 		output: process.cwd(),
 		version: null,
 		ignoreValidation: false,
-		noFileList: false,
+		fileList: true,
 	},
 );
 
@@ -239,9 +239,9 @@ type PackOptions = ValidateOptions & {
 	output?: string;
 
 	/**
-	 * When `true`, the list of packaged files will not be output to the console.
+	 * Determines whether the list of packaged files should be output after packaging.
 	 */
-	noFileList?: boolean;
+	fileList?: boolean;
 
 	/**
 	 * Optional version of the plugin; this will be set in the manifest before bundling.


### PR DESCRIPTION
Adds `--no-file-list` to allow for omitting the list of packaged files after packaging.