### PR TITLE
feat: enable auto-update of JSON schemas from https://schemas.elgato.com

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        node_version: ["20.19.0"]
+        node_version: [20, 24]
         os: ["macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,7 @@
                 "lodash": "^4.17.21",
                 "log-symbols": "^7.0.0",
                 "rage-edit": "^1.2.0",
-                "semver": "^7.6.3",
-                "tar": "^7.5.3"
+                "semver": "^7.6.3"
             },
             "bin": {
                 "sd": "bin/streamdeck.mjs",
@@ -398,6 +397,7 @@
             "integrity": "sha512-c6EW+aA1w2rjqOMjbL93nZlwxp6c1Ln06vTYs5FjRRhmJXK8V/OrSXdT+pUr4aRYgjCgu8/OkiZr0tzeVrRSbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.8",
                 "@typescript-eslint/types": "^8.42.0",
@@ -415,6 +415,7 @@
             "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -1060,7 +1061,6 @@
             "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -1551,17 +1551,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@isaacs/fs-minipass": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.0.tgz",
-            "integrity": "sha512-S00nN1Qt3z3dSP6Db45fj/mksrAq5XWNIJ/SWXGP8XPT2jrzEuYRCSEx08JpJwBcG2F1xgiOtBMGDU0AZHmxew==",
-            "dependencies": {
-                "minipass": "^7.0.4"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -2393,7 +2382,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
             "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
@@ -2420,6 +2408,7 @@
             "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
                 "@typescript-eslint/scope-manager": "8.32.1",
@@ -2476,6 +2465,7 @@
             "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.32.1",
                 "@typescript-eslint/visitor-keys": "8.32.1"
@@ -2494,6 +2484,7 @@
             "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/typescript-estree": "8.32.1",
                 "@typescript-eslint/utils": "8.32.1",
@@ -2518,6 +2509,7 @@
             "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -2532,6 +2524,7 @@
             "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.32.1",
                 "@typescript-eslint/visitor-keys": "8.32.1",
@@ -2559,6 +2552,7 @@
             "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
                 "@typescript-eslint/scope-manager": "8.32.1",
@@ -2583,6 +2577,7 @@
             "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.32.1",
                 "eslint-visitor-keys": "^4.2.0"
@@ -2612,7 +2607,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2708,6 +2702,7 @@
             "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -2840,14 +2835,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/cli-width": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -2888,6 +2875,7 @@
             "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -3017,7 +3005,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -3072,7 +3059,6 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3672,7 +3658,8 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/iconv-lite": {
             "version": "0.7.0",
@@ -3961,6 +3948,7 @@
             "integrity": "sha512-DYYlVP1fe4QBMh2xTIs20/YeTz2GYVbWAEZweHSZD+qQ/Cx2d5RShuhhsdk64eTjNq0FeVnteP/qVOgaywSRbg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -4192,20 +4180,9 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
             }
         },
         "node_modules/mlly": {
@@ -4349,6 +4326,7 @@
             "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parse-statements": "1.0.11"
             }
@@ -4358,7 +4336,8 @@
             "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
             "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -4511,7 +4490,6 @@
             "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -4836,7 +4814,8 @@
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
             "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
             "dev": true,
-            "license": "CC-BY-3.0"
+            "license": "CC-BY-3.0",
+            "peer": true
         },
         "node_modules/spdx-expression-parse": {
             "version": "4.0.0",
@@ -4844,6 +4823,7 @@
             "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -4854,7 +4834,8 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
             "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -4967,30 +4948,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/tar": {
-            "version": "7.5.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tar/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/thenify": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5060,7 +5017,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5096,6 +5052,7 @@
             "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.12"
             },
@@ -5232,7 +5189,6 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "tslib": "^2.8.1",
                 "tsup": "^8.5.1",
                 "typescript": "^5.7.3",
-                "wireit": "^0.14.12"
+                "wireit": "^0.14.13"
             },
             "engines": {
                 "node": ">=20.1.0"
@@ -5260,17 +5260,16 @@
             }
         },
         "node_modules/wireit": {
-            "version": "0.14.12",
-            "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.12.tgz",
-            "integrity": "sha512-gNSd+nZmMo6cuICezYXRIayu6TSOeCSCDzjSF0q6g8FKDsRbdqrONrSZYzdk/uBISmRcv4vZtsno6GyGvdXwGA==",
+            "version": "0.14.13",
+            "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.13.tgz",
+            "integrity": "sha512-Fo/VlEZKY4j53DQoW7Z/fWFrNGbnrfphgVDJdFoas5rVWUA9Z14/3AixEZcEfAuywympLCq49sTXVcD+sNtIxg==",
             "dev": true,
             "license": "Apache-2.0",
             "workspaces": [
-                "vscode-extension",
-                "website"
+                "vscode-extension"
             ],
             "dependencies": {
-                "brace-expansion": "^4.0.0",
+                "brace-expansion": "^5.0.6",
                 "chokidar": "^3.5.3",
                 "fast-glob": "^3.2.11",
                 "jsonc-parser": "^3.0.0",
@@ -5284,26 +5283,26 @@
             }
         },
         "node_modules/wireit/node_modules/balanced-match": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
-            "integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 16"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/wireit/node_modules/brace-expansion": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.1.tgz",
-            "integrity": "sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^3.0.0"
+                "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": ">= 18"
+                "node": "20 || >=22"
             }
         },
         "node_modules/wireit/node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -111,8 +111,7 @@
         "lodash": "^4.17.21",
         "log-symbols": "^7.0.0",
         "rage-edit": "^1.2.0",
-        "semver": "^7.6.3",
-        "tar": "^7.5.3"
+        "semver": "^7.6.3"
     },
     "devDependencies": {
         "@elgato/eslint-config": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
         "build": "wireit",
         "build:bin": "wireit",
         "build:exports": "wireit",
-        "dev": "npm run build --watch",
-        "dev:bin": "npm run build:bin --watch",
-        "dev:exports": "npm run build:exports --watch",
+        "dev": "wireit",
+        "dev:bin": "wireit",
+        "dev:exports": "wireit",
         "lint": "eslint --max-warnings 0",
         "lint:fix": "prettier \"./src/**/*.ts\" --write",
         "preversion": "npm run lint",
@@ -65,6 +65,24 @@
             "dependencies": [
                 "typecheck"
             ]
+        },
+        "dev": {
+            "command": "npm run build",
+            "env": {
+                "WIREIT_WATCH": "true"
+            }
+        },
+        "dev:bin": {
+            "command": "npm run build:bin",
+            "env": {
+                "WIREIT_WATCH": "true"
+            }
+        },
+        "dev:exports": {
+            "command": "npm run build:exports",
+            "env": {
+                "WIREIT_WATCH": "true"
+            }
         },
         "typecheck": {
             "command": "tsc --noEmit",
@@ -128,6 +146,6 @@
         "tslib": "^2.8.1",
         "tsup": "^8.5.1",
         "typescript": "^5.7.3",
-        "wireit": "^0.14.12"
+        "wireit": "^0.14.13"
     }
 }

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "rolldown";
 
-const isWatching = !!(process.env.npm_config_watch || process.env.ROLLUP_WATCH);
+const isWatching = !!process.env.WIREIT_WATCH;
 
 const banner = `#!/usr/bin/env node
 

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -11,13 +11,6 @@ const banner = `#!/usr/bin/env node
  * @copyright Copyright (c) Corsair Memory Inc.
  */`;
 
-// Ignore @elgato/schema to enable auto-update.
-const external = [
-	"@elgato/schemas",
-	"@elgato/schemas/streamdeck/plugins/",
-	"@elgato/schemas/streamdeck/plugins/json",
-];
-
 /**
  * CLI bundling.
  */
@@ -29,7 +22,6 @@ export default defineConfig({
 		sourcemap: isWatching,
 		minify: !isWatching,
 	},
-	external,
 	platform: "node",
 	resolve: {
 		conditionNames: ["node"],

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -3,8 +3,8 @@ import { resolve } from "node:path";
 import { command } from "../common/command";
 import { StdoutError } from "../common/stdout";
 import { store } from "../common/storage";
-import { packageManager } from "../package-manager";
 import { validatePlugin } from "../validation/plugin";
+import { getJsonSchemas } from "../validation/plugin/schemas";
 
 /**
  * Key within the store for the value that records the last update check.
@@ -42,22 +42,18 @@ export const validate = command<ValidateOptions>(async (options, stdout) => {
 		fail();
 	}
 
-	// Determine whether the schemas should be updated.
-	if (canUpdateCheck(options)) {
-		const update = await packageManager.checkUpdate("@elgato/schemas");
-		if (update) {
-			await stdout.spin("Updating validation rules", async () => {
-				await packageManager.install(update);
-				stdout.info(`Validation rules updated`);
-			});
-		}
+	const updateCheck = canUpdateCheck(options);
 
-		// Log the update check.
+	// Validate the plugin and write the output (ignoring success if we should be quiet).
+	const result = await validatePlugin({
+		path: resolve(options.path),
+		schemas: await getJsonSchemas({ updateCheck }),
+	});
+
+	if (updateCheck) {
 		store.set(LAST_UPDATE_CHECK_STORE_KEY, new Date());
 	}
 
-	// Validate the plugin and write the output (ignoring success if we should be quiet).
-	const result = await validatePlugin(resolve(options.path));
 	if (result.hasErrors() || result.hasWarnings() || !options.quietSuccess) {
 		result.writeTo(stdout);
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,16 +103,25 @@ export function updateConfig(updater: (config: object, defaultConfig: Config) =>
 }
 
 /**
+ * Gets the path to the local directory that is responsible for storing files.
+ * @returns The directory path.
+ */
+export function getFileStoreDir(): string {
+	if (platform() === "win32") {
+		const appData = process.env.APPDATA ?? join(homedir(), "AppData/Roaming");
+		return join(appData, "Elgato/MakerCLI/");
+	} else {
+		return join(homedir(), ".config/com.elgato/maker-cli/");
+	}
+}
+
+/**
  * Gets the path to the local configuration file.
  * @returns Configuration file path.
  */
 export function getFilePath(): string {
-	if (platform() === "win32") {
-		const appData = process.env.APPDATA ?? join(homedir(), "AppData/Roaming");
-		return join(appData, "Elgato/MakerCLI/config.json");
-	} else {
-		return join(homedir(), ".config/com.elgato/maker-cli/config.json");
-	}
+	const fileStoreDir = getFileStoreDir();
+	return join(fileStoreDir, "config.json");
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import chalk from "chalk";
 
+import { validatePlugin } from "./validation/plugin";
+import { getJsonSchemas } from "./validation/plugin/schemas";
+import type { ValidationResult } from "./validation/result";
+
 export {
 	ValidationLevel,
 	type FileValidationResult,
@@ -8,6 +12,16 @@ export {
 	type ValidationResult,
 } from "./validation";
 
-export { validatePlugin as validateStreamDeckPlugin } from "./validation/plugin";
+/**
+ * Validates the Stream Deck plugin as the specified {@link path}.
+ * @param path Path to the plugin.
+ * @returns The validation result.
+ */
+export async function validateStreamDeckPlugin(path: string): Promise<ValidationResult> {
+	return validatePlugin({
+		path,
+		schemas: await getJsonSchemas({ updateCheck: true }),
+	});
+}
 
 chalk.level = 0;

--- a/src/json/store.ts
+++ b/src/json/store.ts
@@ -1,0 +1,193 @@
+import { type SchemaObject } from "ajv";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { parse, SemVer } from "semver";
+
+import { getFileStoreDir } from "../config";
+
+/**
+ * A store for loading versioned JSON schemas from remote sources, and a local cache.
+ */
+export const schemaStore = {
+	/**
+	 * Gets a JSON schema from either the local cache, remote source, or the bundled schema, based on
+	 * availability and the version of the schema, as defined within the id.
+	 *
+	 * When the schema is downloaded from the remote source, and newer, the local cache is updated.
+	 * @param opts Options that define how the schema will be loaded.
+	 * @returns The JSON schema.
+	 */
+	get: async (opts: GetOptions): Promise<SchemaObject> => {
+		// Fallback to the default.
+		let curr: VersionedSchemaObject = {
+			schema: opts._default,
+			version: parseVersion(opts._default),
+		};
+
+		// Check if we have a newer cached one.
+		const cached = await getCache(opts.path);
+		if (cached?.version?.compare?.(curr.version) === 1) {
+			curr = cached;
+		}
+
+		// When we can, check if there is a newer remote one that can be cached and returned.
+		if (opts.updateCheck) {
+			const remote = await getRemote(opts.path);
+			if (remote?.version?.compare?.(curr.version) === 1) {
+				curr = remote;
+				await setCache(opts.path, remote.schema);
+			}
+		}
+
+		return curr.schema;
+	},
+};
+
+/**
+ * Gets the JSON schema from the local cache.
+ * @param path Relative path to the schema.
+ * @returns The JSON schema; otherwise undefined it not cached.
+ */
+async function getCache(path: string): Promise<VersionedSchemaObject | undefined> {
+	// Check if we have a local file.
+	const filePath = getCachePath(path);
+	if (!existsSync(filePath)) {
+		return;
+	}
+
+	try {
+		// Parse the schema, and its version
+		const contents = await readFile(filePath, { encoding: "utf8" });
+		const schema = JSON.parse(contents) as SchemaObject;
+
+		return {
+			schema,
+			version: parseVersion(schema),
+		};
+	} catch (e) {
+		console.warn(`Failed to load local schema from ${filePath}`);
+		if (process.env.ELGATO_CLI_DEBUG) {
+			console.log(e);
+		}
+	}
+}
+
+/**
+ * Persists the JSON schema to the local cache
+ * @param path Relative path to the schema.
+ * @param schema The JSON schema to cache.
+ */
+async function setCache(path: string, schema: SchemaObject): Promise<void> {
+	const filePath = getCachePath(path);
+	if (!existsSync(filePath)) {
+		await mkdir(dirname(filePath), { recursive: true });
+	}
+
+	try {
+		// Store the schema to the cache
+		await writeFile(filePath, JSON.stringify(schema), {
+			encoding: "utf8",
+		});
+	} catch (e) {
+		if (process.env.ELGATO_CLI_DEBUG) {
+			console.log(e);
+		}
+	}
+}
+
+/**
+ * Gets the file path of a cached schema.
+ * @param path Relative path to the schema.
+ * @returns The cache file path.
+ */
+function getCachePath(path: string): string {
+	return join(getFileStoreDir(), "schemas", path);
+}
+
+/**
+ * Gets the JSON schema from the remote path, relative to https://schemas.elgato.com/.
+ * @param path Relative path to the schema.
+ * @returns The JSON schema; otherwise undefined if it could not be loaded.
+ */
+async function getRemote(path: string): Promise<VersionedSchemaObject | undefined> {
+	const url = new URL(path, "https://schemas.elgato.com");
+
+	try {
+		// Fetch the remote schema.
+		const res = await fetch(url);
+		if (!res.ok) {
+			throw res;
+		}
+
+		// Parse the contents, and the version.
+		const schema = (await res.json()) as SchemaObject;
+		return {
+			schema,
+			version: parseVersion(schema),
+		};
+	} catch (e) {
+		console.warn(`Failed to load remote schema from ${url}`);
+		if (process.env.ELGATO_CLI_DEBUG) {
+			console.log(e);
+		}
+	}
+}
+
+/**
+ * Parses the version of the JSON schema from the id.
+ * @param schema The schema.
+ * @returns The version.
+ */
+function parseVersion(schema: SchemaObject): SemVer {
+	// We parse the version from the id.
+	const id = schema.$id ?? schema.id;
+	if (id === undefined) {
+		throw new Error('Schema must define an "$id" or "id".');
+	}
+
+	// Ids must be package references, e.g. @elgato/schemas/streamdeck/plugins/manifest@0.4.14
+	const verString = id.split("@").at(-1);
+	const version = parse(verString);
+
+	if (version === null) {
+		throw new Error(`Failed to parse version from schema id: ${id}`);
+	}
+
+	return version;
+}
+
+/**
+ * Extended information about a schema object that represents a JSON schema.
+ */
+interface VersionedSchemaObject {
+	/**
+	 * The version of the schema.
+	 */
+	readonly version: SemVer;
+
+	/**
+	 * The JSON schema.
+	 */
+	readonly schema: SchemaObject;
+}
+
+/**
+ * Options that determine how to load the schema.
+ */
+interface GetOptions {
+	/**
+	 * The default JSON schema.
+	 */
+	readonly _default: SchemaObject;
+
+	/**
+	 * Path to the JSON schema, relative to https://schemas.elgato.com/.
+	 */
+	readonly path: string;
+
+	/**
+	 * Determines whether an update check should occur.
+	 */
+	readonly updateCheck: boolean;
+}

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -1,46 +1,12 @@
-import { createHash } from "node:crypto";
-import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { Readable } from "node:stream";
-import semver from "semver";
-import { extract } from "tar";
+import { existsSync } from "node:fs";
 
-import { dependencies, version } from "../package.json";
-import { moveSync } from "./system/fs";
+import { version } from "../package.json";
 import { relative } from "./system/path";
 
 /**
- * Light-weight package manager that wraps npm, capable of updating locally-scoped installed packages.
+ * Light-weight package manager for interacting with packages.
  */
 class PackageManager {
-	/**
-	 * Checks for an update of the specified package.
-	 * @param name Name of the package.
-	 * @returns The update information; otherwise undefined.
-	 */
-	public async checkUpdate(name: string): Promise<PackageMetadataVersion | undefined> {
-		// Check if the dependency is listed within the CLI's package.json.
-		const range = name in dependencies ? dependencies[name as keyof typeof dependencies] : undefined;
-		if (range === undefined) {
-			throw new Error(`Package is not a dependency, ${name}`);
-		}
-
-		// Get the locally installed package, and registry entries.
-		const installed = this.list(name);
-		const registry = await this.search(name);
-
-		// Get the latest version.
-		const latestVersion = this.getLatestVersion(registry, range);
-		if (latestVersion === undefined) {
-			return;
-		}
-
-		// When there isn't an installed local version, or the latest version is greater, return the latest version.
-		if (installed === undefined || semver.gt(latestVersion.version, installed.version)) {
-			return latestVersion;
-		}
-	}
-
 	/**
 	 * Gets the current version of the CLI from the package JSON file.
 	 * @param opts Version format options.
@@ -53,209 +19,12 @@ class PackageManager {
 
 		return version;
 	}
-
-	/**
-	 * Installs the specified package.
-	 * @param pkg Package to install.
-	 */
-	public async install(pkg: PackageMetadataVersion): Promise<void> {
-		// Download the package's tarball file to a temporary location.
-		const file = relative(`../.tmp/${crypto.randomUUID()}.tar.gz`);
-		mkdirSync(dirname(file), { recursive: true });
-
-		try {
-			await this.download(pkg, file);
-
-			// Determine the package paths.
-			const installationPath = relative(`../node_modules/${pkg.name}`);
-			const tempPath = relative(`../.tmp/${pkg.name}/`);
-
-			// Ensure we have a node_modules folder local to the package.
-			if (!existsSync(installationPath)) {
-				mkdirSync(installationPath, { recursive: true });
-			}
-
-			try {
-				// Move the current installed package, and unpack the new package to node_modules.
-				moveSync(installationPath, tempPath, { overwrite: true });
-				mkdirSync(installationPath, { recursive: true });
-				await extract({
-					file,
-					strip: 1,
-					cwd: installationPath,
-				});
-			} catch (err) {
-				// When something goes wrong, fallback to the previous package.
-				moveSync(tempPath, installationPath, { overwrite: true });
-				throw err;
-			} finally {
-				// Cleanup the temporary cache.
-				if (existsSync(tempPath)) {
-					rmSync(tempPath, { recursive: true });
-				}
-			}
-		} finally {
-			rmSync(file);
-		}
-	}
-
-	/**
-	 * Lists the installed local package.
-	 * @param name Name of the package to list.
-	 * @returns The package; otherwise undefined.
-	 */
-	public list(name: string): Omit<PackageMetadataVersion, "dist"> | undefined {
-		const pkgPath = relative(`../node_modules/${name}`);
-		if (!existsSync(pkgPath)) {
-			return undefined;
-		}
-
-		const pkgJsonPath = join(pkgPath, "package.json");
-		if (!existsSync(pkgJsonPath)) {
-			return undefined;
-		}
-
-		return JSON.parse(readFileSync(pkgJsonPath, { encoding: "utf-8" }));
-	}
-
-	/**
-	 * Searches the npm registry for specified package.
-	 * @param name Package to search for.
-	 * @returns The package; otherwise undefined.
-	 */
-	public async search(name: string): Promise<PackageMetadata> {
-		const res = await fetch(`https://registry.npmjs.org/${name}`, {
-			headers: {
-				Accept: "application/vnd.npm.install-v1+json",
-			},
-		});
-
-		if (res.status !== 200) {
-			throw new Error(`Failed to read package from npm registry with status code ${res.status}`);
-		}
-
-		return (await res.json()) as PackageMetadata;
-	}
-
-	/**
-	 * Downloads the contents of the specified {@link pkg} to the {@link dest} file.
-	 * @param pkg Package to download.
-	 * @param dest File where the packed (i.e. the tarball file) packaged will be downloaded to.
-	 */
-	private async download(pkg: PackageMetadataVersion, dest: string): Promise<void> {
-		if (existsSync(dest)) {
-			throw new Error(`File path already exists: ${dest}`);
-		}
-
-		const res = await fetch(pkg.dist.tarball);
-		if (res.body === null) {
-			throw new Error(`Failed to download package ${pkg.name} from ${pkg.dist.tarball}`);
-		}
-
-		// Create a hash to validate the download.
-		const fileStream = createWriteStream(dest, { encoding: "utf-8" });
-		const body = Readable.fromWeb(res.body);
-		const hash = createHash("sha1");
-
-		return new Promise((resolve, reject) => {
-			fileStream.on("open", () => {
-				// Read the contents of the body into both the file stream, and the hash in parallel.
-				body
-					.on("data", (data) => {
-						hash.update(data);
-						fileStream.write(data);
-					})
-					.on("error", reject)
-					.on("close", () => {
-						fileStream.close(() => {
-							// Validate the shasum.
-							const shasum = hash.digest("hex");
-							if (shasum !== pkg.dist.shasum) {
-								rmSync(dest);
-								reject(`Failed to download package ${pkg.name} from ${pkg.dist.tarball}: shasum mismatch`);
-							}
-
-							resolve();
-						});
-					});
-			});
-		});
-	}
-
-	/**
-	 * Gets the latest version, from the package metadata, that satisfies the {@link range}.
-	 * @param pkg Package metadata whose versions should be checked.
-	 * @param range Range of acceptable versions.
-	 * @returns Latest version; otherwise undefined.
-	 */
-	private getLatestVersion(pkg: PackageMetadata, range: string): PackageMetadataVersion | undefined {
-		return Object.keys(pkg.versions).reduce(
-			(update, version) => {
-				if (semver.satisfies(version, range) && (update === undefined || semver.gt(version, update.version))) {
-					update = pkg.versions[version];
-				}
-
-				return update;
-			},
-			undefined as PackageMetadataVersion | undefined,
-		);
-	}
 }
 
 /**
  * Package manager capable of updating the packages, in the scope of this package.
  */
 export const packageManager = new PackageManager();
-
-/**
- * Provides information about a package, as listed in the npm registry.
- */
-export type PackageMetadata = {
-	/**
-	 * Name of the version.
-	 */
-	name: string;
-
-	/**
-	 * Date the package was last modified.
-	 */
-	modified: Date;
-
-	/**
-	 * Versions of the package.
-	 */
-	versions: Record<string, PackageMetadataVersion>;
-};
-
-/**
- * Provides information about a package version, as listed in the npm registry.
- */
-export type PackageMetadataVersion = {
-	/**
-	 * Name of the version.
-	 */
-	name: string;
-
-	/**
-	 * Version.
-	 */
-	version: string;
-
-	/**
-	 * Information relating to the package's pack file that contains the contents of the package.
-	 */
-	dist: {
-		/**
-		 * Shasum of the tarball file.
-		 */
-		shasum: string;
-
-		/**
-		 * URL to the tarball file that contains the contents of the package.
-		 */
-		tarball: string;
-	};
-};
 
 /**
  * Options for {@link PackageManager.getVersion}.

--- a/src/validation/plugin/index.ts
+++ b/src/validation/plugin/index.ts
@@ -1,5 +1,6 @@
 import type { ValidationResult } from "../result";
 import { validate } from "../validator";
+import type { PluginValidationOptions } from "./options";
 import { createContext, type PluginContext } from "./plugin";
 import { layoutItemsAreWithinBoundsAndNoOverlap } from "./rules/layout-item-bounds";
 import { layoutItemKeysAreUnique } from "./rules/layout-item-keys";
@@ -12,13 +13,13 @@ import { manifestUuids } from "./rules/manifest-uuids";
 import { pathIsDirectoryAndUuid } from "./rules/path-input";
 
 /**
- * Validates the Stream Deck plugin as the specified {@link path}.
- * @param path Path to the plugin.
+ * Validates the Stream Deck plugin as the specified within the options.
+ * @param opts The options used to validate the plugin.
  * @returns The validation result.
  */
-export async function validatePlugin(path: string): Promise<ValidationResult> {
-	const ctx = await createContext(path);
-	return validate<PluginContext>(path, ctx, [
+export async function validatePlugin(opts: PluginValidationOptions): Promise<ValidationResult> {
+	const ctx = createContext(opts);
+	return validate<PluginContext>(opts.path, ctx, [
 		pathIsDirectoryAndUuid,
 		manifestExistsAndSchemaIsValid,
 		manifestFilesExist,

--- a/src/validation/plugin/index.ts
+++ b/src/validation/plugin/index.ts
@@ -13,7 +13,7 @@ import { manifestUuids } from "./rules/manifest-uuids";
 import { pathIsDirectoryAndUuid } from "./rules/path-input";
 
 /**
- * Validates the Stream Deck plugin as the specified within the options.
+ * Validates a Stream Deck plugin.
  * @param opts The options used to validate the plugin.
  * @returns The validation result.
  */

--- a/src/validation/plugin/options.ts
+++ b/src/validation/plugin/options.ts
@@ -1,0 +1,16 @@
+import type { PluginJsonSchemas } from "./schemas";
+
+/**
+ * Options used to validate Stream Deck plugins.
+ */
+export interface PluginValidationOptions {
+	/**
+	 * Path to the plugin.
+	 */
+	path: string;
+
+	/**
+	 * JSON schemas used to validate the plugin.
+	 */
+	schemas: PluginJsonSchemas;
+}

--- a/src/validation/plugin/plugin.ts
+++ b/src/validation/plugin/plugin.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { JsonLocation, LocationRef } from "../../common/location";
 import { JsonFileContext, JsonSchema } from "../../json";
 import { isPredefinedLayoutLike, isValidPluginId } from "../../stream-deck";
+import type { PluginValidationOptions } from "./options";
 
 /**
  * Suffixed associated with a plugin directory.
@@ -13,16 +14,16 @@ export const directorySuffix = ".sdPlugin";
 
 /**
  * Creates a context that represents the plugin.
- * @param path Plugin directory.
+ * @param opts The options that contain the plugin to validate.
  * @returns Plugin context.
  */
-export async function createContext(path: string): Promise<PluginContext> {
-	const id = basename(path).replace(/\.sdPlugin$/, "");
-	const { manifest, layout } = await import("@elgato/schemas/streamdeck/plugins/json");
+export function createContext(opts: PluginValidationOptions): PluginContext {
+	const id = basename(opts.path).replace(/\.sdPlugin$/, "");
+	const { manifest, layout } = opts.schemas;
 
 	return {
 		hasValidId: isValidPluginId(id),
-		manifest: new ManifestJsonFileContext(join(path, "manifest.json"), manifest, layout),
+		manifest: new ManifestJsonFileContext(join(opts.path, "manifest.json"), manifest, layout),
 		id,
 	};
 }

--- a/src/validation/plugin/schemas.ts
+++ b/src/validation/plugin/schemas.ts
@@ -1,0 +1,50 @@
+import { layout, manifest } from "@elgato/schemas/streamdeck/plugins/json";
+import type { SchemaObject } from "ajv";
+
+import { schemaStore } from "../../json/store";
+
+/**
+ * Gets the JSON schemas associated with validating a Stream Deck plugin.
+ * @param param0 The options.
+ * @param param0.updateCheck Determines whether an remote update check should occur.
+ * @returns The JSON schemas.
+ */
+export async function getJsonSchemas({ updateCheck }: Options): Promise<PluginJsonSchemas> {
+	return {
+		layout: await schemaStore.get({
+			_default: layout,
+			path: "/streamdeck/plugins/layout.json",
+			updateCheck,
+		}),
+		manifest: await schemaStore.get({
+			_default: manifest,
+			path: "/streamdeck/plugins/manifest.json",
+			updateCheck,
+		}),
+	};
+}
+
+/**
+ * Options that determine how to load the JSON schemas.
+ */
+interface Options {
+	/**
+	 * Determines whether an update check should occur.
+	 */
+	updateCheck: boolean;
+}
+
+/**
+ * Schemas associated with validating Stream Deck plugins.
+ */
+export interface PluginJsonSchemas {
+	/**
+	 * JSON schema used to validate layouts, such as those found on Stream Deck + and Stream Deck Neo.
+	 */
+	layout: SchemaObject;
+
+	/**
+	 * JSON schema used to validate the manifest.
+	 */
+	manifest: SchemaObject;
+}

--- a/src/validation/plugin/schemas.ts
+++ b/src/validation/plugin/schemas.ts
@@ -6,19 +6,19 @@ import { schemaStore } from "../../json/store";
 /**
  * Gets the JSON schemas associated with validating a Stream Deck plugin.
  * @param param0 The options.
- * @param param0.updateCheck Determines whether an remote update check should occur.
+ * @param param0.updateCheck Determines whether a remote update check should occur.
  * @returns The JSON schemas.
  */
 export async function getJsonSchemas({ updateCheck }: Options): Promise<PluginJsonSchemas> {
 	return {
 		layout: await schemaStore.get({
 			_default: layout,
-			path: "/streamdeck/plugins/layout.json",
+			path: "streamdeck/plugins/layout.json",
 			updateCheck,
 		}),
 		manifest: await schemaStore.get({
 			_default: manifest,
-			path: "/streamdeck/plugins/manifest.json",
+			path: "streamdeck/plugins/manifest.json",
 			updateCheck,
 		}),
 	};


### PR DESCRIPTION
- Replaced auto-update of schemas to use https://schemas.elgato.com.
  - When called within the CLI, the same update rules apply as before.
  - When called programmatically, an update check will occur every time.
- Removed local package manager caching and management.
- Included `@elgato/schemas` in the bundling.
- Removed unused `tar` dependency.